### PR TITLE
Include CC logo via protocol-relative URL.

### DIFF
--- a/intranet/templates/www/base.html
+++ b/intranet/templates/www/base.html
@@ -88,12 +88,12 @@
 
             <div class="row more-space">
                 <div class="span4 ac">
-                    <h3><a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons licenca" style="border-width:0" width="88" height="31" src="http://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a>&nbsp;&nbsp;2001-{% now 'y' %} </h3>
+                    <h3><a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons licenca" style="border-width:0" width="88" height="31" src="//i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a>&nbsp;&nbsp;2001-{% now 'y' %} </h3>
 
                     <p class="cctext">
                         Vsebina spletne strani je, razen kjer 
                         je drugače označeno, na voljo pod licenco <b>Creative Commons</b>
-                        <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Priznanje avtorstva -
+                        <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">Priznanje avtorstva -
                         Deljenje pod enakimi pogoji 4.0</a>.
                     </p>
                     <p class="cctext">


### PR DESCRIPTION
This prevents warning about unsecure content in browsers.
